### PR TITLE
Improve library navigation and empty chapter handling

### DIFF
--- a/src/main/java/dev/tr7zw/mango2j/controller/LibraryController.java
+++ b/src/main/java/dev/tr7zw/mango2j/controller/LibraryController.java
@@ -1,5 +1,6 @@
 package dev.tr7zw.mango2j.controller;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,6 +63,10 @@ public class LibraryController {
             @RequestParam(name = "orderBy", defaultValue = "NEWEST") String orderBy, Model model) {
         // Add necessary attributes to the model
         Title title = titleRepo.getReferenceById(id);
+        Title parent = titleRepo.findByFullPath(new File(title.getFullPath()).getParent());
+        if (parent != null) {
+            model.addAttribute("back", parent.getId());
+        }
         model.addAttribute("is_admin", true); // Example attribute, replace with your logic
         List<Title> titles = titleRepo.findByPath(title.getFullPath());
         titles.sort((a, b) -> a.getName().compareToIgnoreCase(b.getName()));
@@ -96,6 +101,7 @@ public class LibraryController {
         }
         model.addAttribute("chapters", chapters);
         model.addAttribute("name", title.getName());
+        model.addAttribute("path", title.getPath());
         model.addAttribute("orderBy", orderBy.toUpperCase());
         model.addAttribute("chapterThumbnails", generateThumbnails(titles));
         // Return the name of the Thymeleaf template without the extension
@@ -106,7 +112,7 @@ public class LibraryController {
     public String empty(Model model) {
         // Add necessary attributes to the model
         model.addAttribute("is_admin", true); // Example attribute, replace with your logic
-        List<Chapter> chapters = chapterRepo.findByPageCountIsNotNullOrderByPageCountAsc();
+        List<Chapter> chapters = chapterRepo.findEmptyDownloads();
         model.addAttribute("chapters", chapters);
         model.addAttribute("titles", new ArrayList<>());
         model.addAttribute("name", "Empty");

--- a/src/main/java/dev/tr7zw/mango2j/db/ChapterRepository.java
+++ b/src/main/java/dev/tr7zw/mango2j/db/ChapterRepository.java
@@ -3,6 +3,7 @@ package dev.tr7zw.mango2j.db;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChapterRepository extends JpaRepository<Chapter, Integer> {
     // You can add custom query methods here if needed
@@ -11,7 +12,11 @@ public interface ChapterRepository extends JpaRepository<Chapter, Integer> {
     boolean existsByFullPath(String fullPath);
     List<Chapter> findByThumbnailIsNull();
     List<Chapter> findTop100ByOrderByIdDesc();
-    List<Chapter> findByPageCountIsNotNullOrderByPageCountAsc();
+    @Query("SELECT c FROM Chapter c " +
+            "WHERE c.pageCount IS NOT NULL " +
+            "AND (c.views IS NULL OR c.views = 0) " +
+            "ORDER BY c.pageCount ASC")
+    List<Chapter> findEmptyDownloads();
     List<Chapter> findTop100ByOrderByViewsDesc();
     List<Chapter> findTop100ByOrderByViewsAsc();
     

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -35,9 +35,9 @@
         <ul class="uk-navbar-nav">
         <li><a th:href="@{/}">Home</a></li>
         <li><a th:href="@{/library}">Library</a></li>
-		<li><a th:href="@{/empty}">Page count</a></li>
 		<li><a th:href="@{/top}">Most viewed</a></li>
 		<li><a th:href="@{/bottom}">Least viewed</a></li>
+        <li><a th:href="@{/empty}">Failed Empty Chapters</a></li>
         <!--<li><a th:href="@{/tags}">Tags</a></li>
         <li th:if="${is_admin}">
             <li><a th:href="@{/admin}">Admin</a></li>

--- a/src/main/resources/templates/library.html
+++ b/src/main/resources/templates/library.html
@@ -12,10 +12,11 @@
     <div class="uk-section uk-section-small" style="position:relative;">
         <div class="uk-container uk-container-small">
             <h2 class="uk-title" th:text="'Library - ' + (${name != null ? name : 'Home'})"></h2>
-            <p class="uk-text-meta" th:text="${titles.size + chapters.size} + ' titles found'"></p>
+            <a class="uk-text-meta" th:if="${back != null && path != null}" th:text="'Back - ' + ${path}" th:href="'/library/' + ${back}"></a>
+            <p class="uk-text-meta" th:text="${titles.size + chapters.size} + ' entries found'"></p>
 			
             <!-- Box to set the "orderBy"" Parameter for NAME/VIEWS/PAGES/LAST_VIEWED/NEWEST -->
-            <div class="uk-margin-bottom uk-flex uk-flex-between">
+            <div th:if="${!chapters.empty}" class="uk-margin-bottom uk-flex uk-flex-between">
                 <div>
                     <a class="uk-button uk-button-default" th:href="@{?orderBy=newest}">Newest</a>
                     <a class="uk-button uk-button-default" th:href="@{?orderBy=name}">Name</a>


### PR DESCRIPTION
Added parent navigation to the library view, allowing users to go back to the parent directory. Updated the empty chapters query to only show chapters with no views and a page count, and changed the navigation label to 'Failed Empty Chapters'. Also improved the library template to display a back link and clarified entry counts.