### PR TITLE
Add deletion of empty titles in FileScanner

### DIFF
--- a/src/main/java/dev/tr7zw/mango2j/jobs/FileScanner.java
+++ b/src/main/java/dev/tr7zw/mango2j/jobs/FileScanner.java
@@ -67,6 +67,9 @@ public class FileScanner implements DisposableBean {
                     deleteRemovedChapters();
                     if (cancel)
                         return;
+                    deleteEmptyTitles();
+                    if (cancel)
+                        return;
                     triggered = true;
                     log.info("File Scanner task completed.");
                 } else {
@@ -143,6 +146,19 @@ public class FileScanner implements DisposableBean {
             }
         });
     }
+    
+    private void deleteEmptyTitles() {
+        titleRepo.findAll().forEach(dbTitle -> {
+            if (cancel)
+                return;
+            if (chapterRepo.findByPath(dbTitle.getFullPath()).isEmpty()) {
+                File f = new File(dbTitle.getFullPath());
+                titleRepo.delete(dbTitle);
+                log.info("Deleted " + f);
+            }
+        });
+    }
+
 
     @Override
     public void destroy() throws Exception {


### PR DESCRIPTION
Introduces a new method deleteEmptyTitles() that removes titles with no associated chapters. This helps keep the title repository clean by deleting unused title entries during the scanning process.